### PR TITLE
Fixes MULSH opcode and strings decompilation

### DIFF
--- a/xtensa.py
+++ b/xtensa.py
@@ -211,8 +211,7 @@ class XtensaProcessor(processor_t):
     instruc_start = 0
 
     assembler = {
-        "flag": ASH_HEXF3 | ASD_DECF0 | ASO_OCTF1 | ASB_BINF3 | AS_NOTAB
-            | AS_ASCIIC | AS_ASCIIZ,
+        "flag": ASH_HEXF3 | ASD_DECF0 | ASO_OCTF1 | ASB_BINF3 | AS_NOTAB,
         "uflag": 0,
         "name": "GNU assembler",
         "origin": ".org",
@@ -384,7 +383,7 @@ class XtensaProcessor(processor_t):
         ("mula.dd.hl",    0x2a0004, 0xffbfbf, Instr.fmt_RRR_mul_dd ),
         ("mula.dd.hh",    0x2b0004, 0xffbfbf, Instr.fmt_RRR_mul_dd ),
         ("mull",   0x820000, 0xff000f, Instr.fmt_RRR ),
-        ("mulsh",  0xb10000, 0xff000f, Instr.fmt_RRR ),
+        ("mulsh",  0xb20000, 0xff000f, Instr.fmt_RRR ),
         ("mul16s", 0xd10000, 0xff000f, Instr.fmt_RRR ),
         ("mul16u", 0xc10000, 0xff000f, Instr.fmt_RRR ),
         ("muluh",  0xa20000, 0xff000f, Instr.fmt_RRR ),

--- a/xtensa.py
+++ b/xtensa.py
@@ -211,8 +211,6 @@ class XtensaProcessor(processor_t):
     instruc_start = 0
 
     assembler = {
-        "flag": ASH_HEXF3 | ASD_DECF0 | ASO_OCTF1 | ASB_BINF3 | AS_NOTAB
-            | AS_ASCIIC | AS_ASCIIZ,
         "uflag": 0,
         "name": "GNU assembler",
         "origin": ".org",
@@ -384,7 +382,7 @@ class XtensaProcessor(processor_t):
         ("mula.dd.hl",    0x2a0004, 0xffbfbf, Instr.fmt_RRR_mul_dd ),
         ("mula.dd.hh",    0x2b0004, 0xffbfbf, Instr.fmt_RRR_mul_dd ),
         ("mull",   0x820000, 0xff000f, Instr.fmt_RRR ),
-        ("mulsh",  0xb10000, 0xff000f, Instr.fmt_RRR ),
+        ("mulsh",  0xb20000, 0xff000f, Instr.fmt_RRR ),
         ("mul16s", 0xd10000, 0xff000f, Instr.fmt_RRR ),
         ("mul16u", 0xc10000, 0xff000f, Instr.fmt_RRR ),
         ("muluh",  0xa20000, 0xff000f, Instr.fmt_RRR ),

--- a/xtensa.py
+++ b/xtensa.py
@@ -211,6 +211,8 @@ class XtensaProcessor(processor_t):
     instruc_start = 0
 
     assembler = {
+        "flag": ASH_HEXF3 | ASD_DECF0 | ASO_OCTF1 | ASB_BINF3 | AS_NOTAB
+            | AS_ASCIIC | AS_ASCIIZ,
         "uflag": 0,
         "name": "GNU assembler",
         "origin": ".org",
@@ -382,7 +384,7 @@ class XtensaProcessor(processor_t):
         ("mula.dd.hl",    0x2a0004, 0xffbfbf, Instr.fmt_RRR_mul_dd ),
         ("mula.dd.hh",    0x2b0004, 0xffbfbf, Instr.fmt_RRR_mul_dd ),
         ("mull",   0x820000, 0xff000f, Instr.fmt_RRR ),
-        ("mulsh",  0xb20000, 0xff000f, Instr.fmt_RRR ),
+        ("mulsh",  0xb10000, 0xff000f, Instr.fmt_RRR ),
         ("mul16s", 0xd10000, 0xff000f, Instr.fmt_RRR ),
         ("mul16u", 0xc10000, 0xff000f, Instr.fmt_RRR ),
         ("muluh",  0xa20000, 0xff000f, Instr.fmt_RRR ),


### PR DESCRIPTION
- From page 455 of Xtensa (ISA) Reference Manual the opcode for MULSH is 0xB2 not 0xB1. B1 is SRA

- AS_ASCIIC | AS_ASCIIZ flags do not get zeroed out when this dictionary is initialized and therefore strings are not displayed properly. May just be an issue with my version of IDA. Ignore if strings show up correctly on your version.